### PR TITLE
allow different versions of `_post_init_`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ class Human(ZnInit):
     language: str = Input("DE")
     date: str = Metric()  # will not appear in the __init__
 
-    def post_init(self):
+    def _post_init_(self):
         self.date = "2022-09-16"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "zninit"
-version = "0.1.5"
+version = "0.1.6"
 description = "Descriptor based dataclass implementation"
 authors = ["zincwarecode <zincwarecode@gmail.com>"]
 license = "Apache-2.0"

--- a/tests/test_AutomaticInit.py
+++ b/tests/test_AutomaticInit.py
@@ -1,6 +1,7 @@
 """Test for the automatic __init__."""
 import pytest
 
+import zninit
 from zninit import Descriptor, ZnInit
 
 # autocomplete issue https://youtrack.jetbrains.com/issue/PY-38072
@@ -199,3 +200,42 @@ def test_OnlyParamsInInit(cls):
 
     with pytest.raises(TypeError):
         cls(parameter=10, output=25)
+
+
+class PostInitA(zninit.ZnInit):
+    """Class with 'post_init'."""
+
+    parameter = zninit.Descriptor()
+    called = False
+
+    def post_init(self):
+        """Post init call."""
+        self.called = True
+
+
+class PostInitB(zninit.ZnInit):
+    """Class with '_post_init_'."""
+
+    parameter = zninit.Descriptor()
+    called = False
+
+    def _post_init_(self):
+        """Post init call."""
+        self.called = True
+
+
+class PostInitC(zninit.ZnInit):
+    """Class with '__post_init__'."""
+
+    parameter = zninit.Descriptor()
+    called = False
+
+    def __post_init__(self):
+        """Post init call."""
+        self.called = True
+
+
+@pytest.mark.parametrize("cls", (PostInitA, PostInitB, PostInitC))
+def test_post_init_called(cls):
+    """Test different versions of '_post_init_'."""
+    assert cls(parameter="Test").called

--- a/tests/test_zninit.py
+++ b/tests/test_zninit.py
@@ -5,4 +5,4 @@ import zninit
 
 def test_version():
     """Test the installed version."""
-    assert zninit.__version__ == "0.1.5"
+    assert zninit.__version__ == "0.1.6"

--- a/zninit/core/__init__.py
+++ b/zninit/core/__init__.py
@@ -1,7 +1,6 @@
 """Functionality to generate the automatic __init__."""
 from __future__ import annotations
 
-import contextlib
 import logging
 import typing
 from copy import deepcopy
@@ -105,8 +104,9 @@ def get_auto_init(
         for key, value in init_kwargs.items():
             setattr(self, key, value)
 
-        with contextlib.suppress(AttributeError):
-            self.post_init()
+        for post_init in ["__post_init__", "_post_init_", "post_init"]:
+            if hasattr(self, post_init):
+                getattr(self, post_init)()
 
     # we add this attribute to the __init__ to make it identifiable
     auto_init.uses_auto_init = True
@@ -114,7 +114,7 @@ def get_auto_init(
     return auto_init
 
 
-class ZnInit:
+class ZnInit:  # pylint: disable=R0903
     """Parent class for automatic __init__ generation based on descriptors.
 
     Attributes
@@ -276,10 +276,9 @@ class ZnInit:
         repr_str += ")"
         return repr_str
 
-    def post_init(self):
+    def _post_init_(self):
         """Implement if cmds after the automatically generated __init__ should be run.
 
         This only works if no __init__ is defined and the automatically generated
         __init__ is used.
         """
-        raise AttributeError(f"'{self}' object has no attribute 'post_init'")


### PR DESCRIPTION
Note: The order goes from '__' -> '_' -> '' and they will all be called if multiple ones are defined.