### PR TITLE
add support for type checkers using @dataclass_transform from PEP 681…

### DIFF
--- a/zninit/__init__.py
+++ b/zninit/__init__.py
@@ -4,7 +4,8 @@ import importlib.metadata
 
 from zninit.core import ZnInit
 from zninit.descriptor import Descriptor, Empty, get_descriptors
+from zninit.descriptor.desc import desc
 
-__all__ = ("Descriptor", "ZnInit", "get_descriptors", "Empty")
+__all__ = ("Descriptor", "ZnInit", "get_descriptors", "Empty", "desc")
 
 __version__ = importlib.metadata.version("zninit")

--- a/zninit/core/__init__.py
+++ b/zninit/core/__init__.py
@@ -13,6 +13,7 @@ from zninit.descriptor import Descriptor, Empty, get_descriptors
 if sys.version_info >= (3, 11):
     from typing import dataclass_transform
 else:
+
     def dataclass_transform(*args, **kwargs):
         """Empty decorator for Python < 3.11 support"""
 
@@ -20,6 +21,7 @@ else:
             return func
 
         return decorator
+
 
 log = logging.getLogger(__name__)
 

--- a/zninit/core/__init__.py
+++ b/zninit/core/__init__.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import logging
+import sys
 import typing
 from copy import deepcopy
 from inspect import Parameter, Signature
 
 from zninit.descriptor import Descriptor, Empty, get_descriptors
 
-import sys
 if sys.version_info >= (3, 11):
     from typing import dataclass_transform
 else:

--- a/zninit/core/__init__.py
+++ b/zninit/core/__init__.py
@@ -9,6 +9,12 @@ from inspect import Parameter, Signature
 
 from zninit.descriptor import Descriptor, Empty, get_descriptors
 
+import sys
+if sys.version_info >= (3, 11):
+    from typing import dataclass_transform
+else:
+    from typing_extensions import dataclass_transform
+
 log = logging.getLogger(__name__)
 
 
@@ -258,6 +264,7 @@ def _get_auto_init_signature(cls) -> typing.Tuple[list, dict, list]:
     return signature_params
 
 
+@dataclass_transform(field_specifiers=(Descriptor,))
 class ZnInit:  # pylint: disable=R0903
     """Parent class for automatic __init__ generation based on descriptors.
 

--- a/zninit/core/__init__.py
+++ b/zninit/core/__init__.py
@@ -13,7 +13,13 @@ import sys
 if sys.version_info >= (3, 11):
     from typing import dataclass_transform
 else:
-    from typing_extensions import dataclass_transform
+    def dataclass_transform(*args, **kwargs):
+        """Empty decorator for Python < 3.11 support"""
+
+        def decorator(func):
+            return func
+
+        return decorator
 
 log = logging.getLogger(__name__)
 

--- a/zninit/core/__init__.py
+++ b/zninit/core/__init__.py
@@ -14,7 +14,7 @@ if sys.version_info >= (3, 11):
     from typing import dataclass_transform
 else:
     def dataclass_transform(*args, **kwargs):
-        """Empty decorator for Python < 3.11 support"""
+        """Empty decorator for Python < 3.11 support."""
 
         def decorator(func):
             return func

--- a/zninit/descriptor/__init__.py
+++ b/zninit/descriptor/__init__.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 import contextlib
+import enum
 import functools
 import sys
 import typing
 import weakref
-import enum
 
 with contextlib.suppress(ImportError):
     import typeguard
+
 
 # See https://github.com/python/cpython/blob/main/Lib/dataclasses.py#L181.
 class _Empty_TYPE(enum.Enum):  # pylint: disable=too-few-public-methods
@@ -19,7 +20,9 @@ class _Empty_TYPE(enum.Enum):  # pylint: disable=too-few-public-methods
     When checking if something has a default we can not use 'value is None'
     because 'None' could be the default. Therefore, we use 'value is zninit.Empty'
     """
+
     Empty = enum.auto()
+
 
 Empty = _Empty_TYPE.Empty
 

--- a/zninit/descriptor/__init__.py
+++ b/zninit/descriptor/__init__.py
@@ -56,9 +56,9 @@ class Descriptor:  # pylint: disable=too-many-instance-attributes
         use_repr: bool = True,
         repr_func: typing.Callable = repr,
         check_types: bool = False,
-        metadata: dict = None,
+        metadata: typing.Optional[dict] = None,
         frozen: bool = False,
-        on_setattr: typing.Callable = None,
+        on_setattr: typing.Optional[typing.Callable] = None,
     ):  # pylint: disable=too-many-arguments
         """Define a Descriptor object.
 

--- a/zninit/descriptor/__init__.py
+++ b/zninit/descriptor/__init__.py
@@ -7,17 +7,21 @@ import functools
 import sys
 import typing
 import weakref
+import enum
 
 with contextlib.suppress(ImportError):
     import typeguard
 
-
-class Empty:  # pylint: disable=too-few-public-methods
+# See https://github.com/python/cpython/blob/main/Lib/dataclasses.py#L181.
+class _Empty_TYPE(enum.Enum):  # pylint: disable=too-few-public-methods
     """ZnInit Version of None to distinguish default version from None.
 
     When checking if something has a default we can not use 'value is None'
     because 'None' could be the default. Therefore, we use 'value is zninit.Empty'
     """
+    Empty = enum.auto()
+
+Empty = _Empty_TYPE.Empty
 
 
 class Descriptor:  # pylint: disable=too-many-instance-attributes

--- a/zninit/descriptor/desc.py
+++ b/zninit/descriptor/desc.py
@@ -6,16 +6,16 @@ from zninit.descriptor import Descriptor, Empty
 
 
 def desc(
-        default=Empty,
-        owner=None,
-        instance=None,
-        name="",
-        use_repr: bool = True,
-        repr_func: Callable = repr,
-        check_types: bool = False,
-        metadata: Optional[dict] = None,
-        frozen: bool = False,
-        on_setattr: Optional[Callable] = None,
+    default=Empty,
+    owner=None,
+    instance=None,
+    name="",
+    use_repr: bool = True,
+    repr_func: Callable = repr,
+    check_types: bool = False,
+    metadata: Optional[dict] = None,
+    frozen: bool = False,
+    on_setattr: Optional[Callable] = None,
 ):
     """Create a Descriptor object.
 

--- a/zninit/descriptor/desc.py
+++ b/zninit/descriptor/desc.py
@@ -4,17 +4,17 @@ from zninit.descriptor import Descriptor, Empty
 
 
 def desc(
-        default=Empty,
-        owner=None,
-        instance=None,
-        name="",
-        use_repr: bool = True,
-        repr_func: Callable = repr,
-        check_types: bool = False,
-        metadata: Optional[dict] = None,
-        frozen: bool = False,
-        on_setattr: Optional[Callable] = None,
-    ):
+    default=Empty,
+    owner=None,
+    instance=None,
+    name="",
+    use_repr: bool = True,
+    repr_func: Callable = repr,
+    check_types: bool = False,
+    metadata: Optional[dict] = None,
+    frozen: bool = False,
+    on_setattr: Optional[Callable] = None,
+):
     """Factory function that creates a Descriptor object.
 
     Forwards all arguments to the Descriptor.__init__ method.

--- a/zninit/descriptor/desc.py
+++ b/zninit/descriptor/desc.py
@@ -1,3 +1,5 @@
+"""Provide a typed factory function for descriptors."""
+
 from typing import Callable, Optional
 
 from zninit.descriptor import Descriptor, Empty
@@ -15,7 +17,7 @@ def desc(
         frozen: bool = False,
         on_setattr: Optional[Callable] = None,
     ):
-    """Factory function that creates a Descriptor object.
+    """Create a Descriptor object.
 
     Forwards all arguments to the Descriptor.__init__ method.
     The return type is annotated as the type of the managed attribute

--- a/zninit/descriptor/desc.py
+++ b/zninit/descriptor/desc.py
@@ -1,0 +1,35 @@
+from typing import Callable, Optional
+
+from zninit.descriptor import Descriptor, Empty
+
+
+def desc(
+        default=Empty,
+        owner=None,
+        instance=None,
+        name="",
+        use_repr: bool = True,
+        repr_func: Callable = repr,
+        check_types: bool = False,
+        metadata: Optional[dict] = None,
+        frozen: bool = False,
+        on_setattr: Optional[Callable] = None,
+    ):
+    """Factory function that creates a Descriptor object.
+
+    Forwards all arguments to the Descriptor.__init__ method.
+    The return type is annotated as the type of the managed attribute
+    to enable dataclass semantics, see stub file desc.pyi.
+    """
+    return Descriptor(
+        default=default,
+        owner=owner,
+        instance=instance,
+        name=name,
+        use_repr=use_repr,
+        repr_func=repr_func,
+        check_types=check_types,
+        metadata=metadata,
+        frozen=frozen,
+        on_setattr=on_setattr,
+    )

--- a/zninit/descriptor/desc.pyi
+++ b/zninit/descriptor/desc.pyi
@@ -1,0 +1,45 @@
+from typing import Any, Callable, Optional, overload, TypeVar
+
+from zninit.descriptor import Empty
+
+
+_T = TypeVar('_T')
+
+
+# In reality, desc returns a Descriptor object. We lie about this
+# and pretend it returns an object of the type of the managed attribute
+# to enable dataclass semantics with type checkers, i.e.:
+#
+# class Human(ZnInit):
+#     age: int = desc(0)
+
+# If no default value is given, we pretend the return type is Any.
+# The actual type will be inferred from the annotation in the class.
+@overload
+def desc(
+        default: Empty = ...,
+        owner=...,
+        instance=...,
+        name=...,
+        use_repr: bool = ...,
+        repr_func: Callable = ...,
+        check_types: bool = False,
+        metadata: Optional[dict] = ...,
+        frozen: bool = False,
+        on_setattr: Optional[Callable] = ...,
+    ) -> Any: ...
+
+# If a default value is given, we pretend its type is the return type.
+@overload
+def desc(
+        default: _T,
+        owner=...,
+        instance=...,
+        name=...,
+        use_repr: bool = ...,
+        repr_func: Callable = ...,
+        check_types: bool = False,
+        metadata: Optional[dict] = ...,
+        frozen: bool = False,
+        on_setattr: Optional[Callable] = ...,
+    ) -> _T: ...

--- a/zninit/descriptor/desc.pyi
+++ b/zninit/descriptor/desc.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, TypeVar, overload, Literal
+from typing import Any, Callable, Literal, Optional, TypeVar, overload
 
 from zninit.descriptor import _Empty_TYPE
 

--- a/zninit/descriptor/desc.pyi
+++ b/zninit/descriptor/desc.pyi
@@ -1,6 +1,6 @@
-from typing import Any, Callable, Optional, TypeVar, overload
+from typing import Any, Callable, Optional, TypeVar, overload, Literal
 
-from zninit.descriptor import Empty
+from zninit.descriptor import _Empty_TYPE
 
 _T = TypeVar("_T")
 
@@ -15,7 +15,7 @@ _T = TypeVar("_T")
 # The actual type will be inferred from the annotation in the class.
 @overload
 def desc(
-    default: Empty = ...,
+    default: Literal[_Empty_TYPE.Empty] = ...,
     owner=...,
     instance=...,
     name=...,

--- a/zninit/descriptor/desc.pyi
+++ b/zninit/descriptor/desc.pyi
@@ -1,10 +1,8 @@
-from typing import Any, Callable, Optional, overload, TypeVar
+from typing import Any, Callable, Optional, TypeVar, overload
 
 from zninit.descriptor import Empty
 
-
-_T = TypeVar('_T')
-
+_T = TypeVar("_T")
 
 # In reality, desc returns a Descriptor object. We lie about this
 # and pretend it returns an object of the type of the managed attribute
@@ -17,29 +15,29 @@ _T = TypeVar('_T')
 # The actual type will be inferred from the annotation in the class.
 @overload
 def desc(
-        default: Empty = ...,
-        owner=...,
-        instance=...,
-        name=...,
-        use_repr: bool = ...,
-        repr_func: Callable = ...,
-        check_types: bool = False,
-        metadata: Optional[dict] = ...,
-        frozen: bool = False,
-        on_setattr: Optional[Callable] = ...,
-    ) -> Any: ...
+    default: Empty = ...,
+    owner=...,
+    instance=...,
+    name=...,
+    use_repr: bool = ...,
+    repr_func: Callable = ...,
+    check_types: bool = False,
+    metadata: Optional[dict] = ...,
+    frozen: bool = False,
+    on_setattr: Optional[Callable] = ...,
+) -> Any: ...
 
 # If a default value is given, we pretend its type is the return type.
 @overload
 def desc(
-        default: _T,
-        owner=...,
-        instance=...,
-        name=...,
-        use_repr: bool = ...,
-        repr_func: Callable = ...,
-        check_types: bool = False,
-        metadata: Optional[dict] = ...,
-        frozen: bool = False,
-        on_setattr: Optional[Callable] = ...,
-    ) -> _T: ...
+    default: _T,
+    owner=...,
+    instance=...,
+    name=...,
+    use_repr: bool = ...,
+    repr_func: Callable = ...,
+    check_types: bool = False,
+    metadata: Optional[dict] = ...,
+    frozen: bool = False,
+    on_setattr: Optional[Callable] = ...,
+) -> _T: ...


### PR DESCRIPTION
… and a typed factory function for descriptors

Works on my machine (TM), stolen from attrs and decently elegant IMO.

Example usage:
```python
from zninit import ZnInit, desc

class Human(ZnInit):
    name: str = desc()
    age: int = desc(23)


fabian = Human(name="Fabian", age=25)

reveal_type(fabian.name)  # Revealed type is 'str'
reveal_type(fabian.age)  # Revealed type is 'int'
```